### PR TITLE
call `Realm.init` before get instance

### DIFF
--- a/app/src/main/java/xyz/yyagi/travelbase/service/RealmBuilder.java
+++ b/app/src/main/java/xyz/yyagi/travelbase/service/RealmBuilder.java
@@ -10,7 +10,7 @@ import io.realm.RealmConfiguration;
  */
 public class RealmBuilder {
     public static Realm getRealmInstance(Context context) {
-        // TODO: remove context
+        Realm.init(context);
         return Realm.getDefaultInstance();
     }
 


### PR DESCRIPTION
Although the cause is uncertain, an error is generated occasionally due to the
fact that init is not done, so we are calling init explicitly.

Ref: https://console.firebase.google.com/project/fine-chariot-95502/monitoring/app/android:xyz.yyagi.travelbase/cluster/da4c9826?duration=15811200000